### PR TITLE
Fix: at module unload, destroy previously allocated hash tables

### DIFF
--- a/mod_mosquitto.c
+++ b/mod_mosquitto.c
@@ -124,6 +124,7 @@ SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_mosquitto_shutdown)
 
 	mosq_shutdown();
 	
+	switch_core_hash_destroy(&mosquitto_globals.profiles);
 	switch_mutex_destroy(mosquitto_globals.profiles_mutex);
 	switch_mutex_unlock(mosquitto_globals.mutex);
 	switch_mutex_destroy(mosquitto_globals.mutex);

--- a/mosquitto_mosq.c
+++ b/mosquitto_mosq.c
@@ -1623,7 +1623,7 @@ switch_status_t mosq_shutdown(void)
 
 	switch_mutex_lock(mosquitto_globals.profiles_mutex);
 	for (switch_hash_index_t *profiles_hi = switch_core_hash_first(mosquitto_globals.profiles); profiles_hi;
-		 profiles_hi = switch_core_hash_next(&profiles_hi)) {
+		profiles_hi = switch_core_hash_next(&profiles_hi)) {
 		mosquitto_profile_t *profile = NULL;
 		void *val;
 		switch_core_hash_this(profiles_hi, NULL, NULL, &val);

--- a/mosquitto_utils.c
+++ b/mosquitto_utils.c
@@ -347,7 +347,7 @@ switch_status_t publisher_topic_deactivate(mosquitto_profile_t *profile, mosquit
 	if (topic->enable) {
 		switch_mutex_lock(topic->events_mutex);
 		for (switch_hash_index_t *events_hi = switch_core_hash_first(topic->events); events_hi;
-			 events_hi = switch_core_hash_next(&events_hi)) {
+			events_hi = switch_core_hash_next(&events_hi)) {
 			mosquitto_event_t *event = NULL;
 			void *val;
 			switch_core_hash_this(events_hi, NULL, NULL, &val);


### PR DESCRIPTION
Valgrind detected some memory not being cleaned up.  This update takes care of the problem.